### PR TITLE
Slow down clock to 1MHz for addresses in ranges B000-B3FF and B800-BBFF

### DIFF
--- a/decoder.vhd
+++ b/decoder.vhd
@@ -73,6 +73,7 @@ architecture Behavioral of decoder is
 	signal regBFFE:            STD_LOGIC_VECTOR(7 downto 0) := x"06";
    signal ledBFFD:            STD_LOGIC_VECTOR(7 downto 0);
    signal BFFX:               STD_LOGIC;
+   signal nBXXX:              STD_LOGIC;
 	signal RD, WR, WP:			STD_LOGIC;
 	signal BS0, BS1, BS2:		STD_LOGIC;
 	signal XMA0, XMA1, XMA2:	STD_LOGIC;


### PR DESCRIPTION
This allows 7445 Programmable Peripheral Interface to operate with the 6502 clock at 4MHz